### PR TITLE
A few fixes

### DIFF
--- a/00_Slides.fsx
+++ b/00_Slides.fsx
@@ -170,5 +170,5 @@ let tree = Branch (Branch (Branch (Leaf 2,Leaf 3),Leaf 7),Leaf 1)
 match tree with
 | Leaves (items,root) -> 
     printfn "%A" root
-    for item in items do 
-      printfn "%A" items
+    for item in items do
+      printfn "%A" item

--- a/00_Slides.fsx
+++ b/00_Slides.fsx
@@ -18,7 +18,7 @@ for i in 1 .. 100 do
   | 0,0 -> printfn "FizzBuzz"
   | 0,_ -> printfn "Fizz"
   | _,0 -> printfn "Buzz"
-  | n   -> printfn "%s" (string n)
+  | _,_ -> printfn "%s" (string n)
 
 (* ________________________________________________________________________________ *)
 
@@ -109,7 +109,7 @@ let (|Fizz|Buzz|FizzBuzz|Num|) n =
   | 0,0 -> FizzBuzz
   | 0,_ -> Fizz
   | _,0 -> Buzz
-  | n   -> Num n
+  | _,_   -> Num n
 
 for i in 1 .. 100 do
   match i with

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DeepDive_ActivePatterns
-(Nearly) Everything you Ever Wanted to Know About Active Patterns (but Were Afraid to Ask)
+(Nearly) Everything you Ever Wanted to Know About Active Patterns (but Were Afraid to Ask)
 
 Slides and scripts about using Active Patterns in F#.
 


### PR DESCRIPTION
I was reviewing this as a chance to show some others more about active patterns and noticed there were a few problems in the code. I've fixed a few of them but I haven't gone through all of the code yet, nor fixed up the copy of the code in the slides. Most of the issues are with using the wrong values (either via shadowing—not sure why F# doesn't warn on pattern binding shadowing by default, or simple typos)

On the tree example, I do think it's a little contrived and so I set out to look at some alternatives to exemplify patterns as values. If I had more traditional binary tree like:

```fsharp
type Tree<'T> =
| Leaf
| Branch of 'T * Tree<'T> * Tree<'T>
```

Where Leaf is like the tree equivalent of Nil and Branch is the tree equivalent of Cons. Unfortunately it's a little harder to walk since we want to actually visit all of the nodes, so the branch code becomes a little more involved. A consideration could be made that the Tree walk could be separated from the element selection. At this point I'm a little undecided if this is a case where active patters make sense since the latter is more like a filter function and the prior expresses preorder, postorder, and inorder walks which seem a bit hard to shove into a partial pattern (maybe I'm missing a clever encoding that controls the order of yields as well as ascending and descending order). 
